### PR TITLE
Small change to instructions in READme and an Error message regarding preserveCompilationContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,4 +118,11 @@ public HomeController(IRazorLightEngine engine)
 
 ## FAQ
 ### I'm getting "Can't load metadata reference from the entry assembly" exception
-Just set ```preserveCompilationContext": true``` in your project.json
+Just set ```preserveCompilationContext": true``` under the buildOptions section in your project.json.
+Example:
+```
+"buildOptions": {
+    ...
+    "preserveCompilationContext": true
+}
+```

--- a/README.md
+++ b/README.md
@@ -119,10 +119,19 @@ public HomeController(IRazorLightEngine engine)
 ## FAQ
 ### I'm getting "Can't load metadata reference from the entry assembly" exception
 Just set ```preserveCompilationContext": true``` under the buildOptions section in your project.json.
-Example:
+
+Example project.json:
 ```
-"buildOptions": {
+{
+    "version": "x.x.x.x",
+    
     ...
-    "preserveCompilationContext": true
+    
+    "buildOptions": {
+        ...
+        "preserveCompilationContext": true
+    }
+
+    ...
 }
 ```

--- a/src/RazorLight/UseEntryAssemblyMetadataResolver.cs
+++ b/src/RazorLight/UseEntryAssemblyMetadataResolver.cs
@@ -29,7 +29,7 @@ namespace RazorLight
 			if (!metadataReferences.Any())
 			{
 				throw new RazorLightException("Can't load metadata reference from the entry assembly. " +
-					"Make sure preserveCompilationContext is set to true in compilerOptions section of project.json");
+					"Make sure preserveCompilationContext is set to true in buildOptions section of project.json");
 			}
 #elif NET451
 			//DependencyContext works also on 4.5.1, but requires new project.json project structure


### PR DESCRIPTION
Hi @toddams ,

I recently installed your library as a dependency in a project and I had the "Can't load metadata reference from the entry assembly" exception when I tried to render a template.

Following the FAQ in the READme I added `"preserveCompilationContext": true` under `compilationOptions` in the project.json, but I still had the same exception thrown.

Then I tried to add `"preserveCompilationContext": true` under the `buildOptions` and then it worked.

In this pull request I changed the instructions in the READme file and in the error message contained in the exception to indicate that `"preserveCompilationContext": true` should be set under the `buildOptions` section.

I hope that this small contribution will make it less confusing for the users of the library to deal with this configuration detail.

Regards. 

