### PR TITLE
README: mention the need of clean rebuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ public HomeController(IRazorLightEngine engine)
 ### I'm getting "Can't load metadata reference from the entry assembly" exception
 Just set ```preserveCompilationContext": true``` under the buildOptions section in your project.json OR *.csproj file
 
+⚠ Don't forget to clean and rebuild the project after this change!
+
 Example project.json:
 ```
 {


### PR DESCRIPTION
That's likely to be an issue for anyone who have built the project, encountered this problem and trying to fix it without executing `dotnet clean` or cleaning it with Visual Studio. So I propose to add a warning about that into README.

Likely the confusion in #44 was caused by this (not cleaning the project before build).