### PR TITLE
Pass ViewBag to RenderTemplateAsync

### DIFF
--- a/src/RazorLight/RazorLightEngine.cs
+++ b/src/RazorLight/RazorLightEngine.cs
@@ -86,7 +86,7 @@ namespace RazorLight
         {
             using (var writer = new StringWriter())
             {
-                await RenderTemplateAsync(templatePage, model, modelType, writer);
+                await RenderTemplateAsync(templatePage, model, modelType, writer, viewBag);
                 string result = writer.ToString();
 
                 return result;


### PR DESCRIPTION
This is a small fix, to pass viewbag through whole call tree.
Currently CompileRenderAsync and some overloads of RenderTemplateAsync fails if you need to pass viewbug