### PR TITLE
fixed ArgumentException in AddDynamicTemplates, removed unnecessary IsNullOrEmpty check in RawString

### DIFF
--- a/src/RazorLight/RazorLightEngineBuilder.cs
+++ b/src/RazorLight/RazorLightEngineBuilder.cs
@@ -132,12 +132,7 @@ namespace RazorLight
                 throw new ArgumentNullException(nameof(dynamicTemplates));
             }
 
-            this.dynamicTemplates = new ConcurrentDictionary<string, string>();
-
-            foreach (var pair in dynamicTemplates)
-            {
-                dynamicTemplates.Add(pair);
-            }
+            this.dynamicTemplates = new ConcurrentDictionary<string, string>(dynamicTemplates);
 
             return this;
         }

--- a/src/RazorLight/Text/RawString.cs
+++ b/src/RazorLight/Text/RawString.cs
@@ -24,7 +24,7 @@ namespace RazorLight.Text
         /// <param name="value">The value</param>
         public RawString(string value)
         {
-            if(string.IsNullOrEmpty(value))
+            if (value == null)
             {
                 throw new ArgumentNullException(nameof(value));
             }


### PR DESCRIPTION
**RazorLightEngineBuilder.cs -> AddDynamicTemplates()**
_Bug:_
takes `dynamicTemplates `dict as an argument, then `foreach`es through it while readding the template key-value pairs to the same dict, basically copying the entries (fails with a `ArgumentException("An item with the same key has already been added.")` exception, as it should). Could be that the developers meant for it to `Add()` to the `this.dynamicTemplates` dict, but that is a `ConcurrentDictionary`, which does not have an `Add()` function (because simply adding is not thread safe), only a `TryAdd `function. 
_Fix:_
Anyway, constructing the `ConcurrentDictionary `with our dictionary as a param is much simpler and, imo, clearer.

**Text/RawString.cs constructor(value)**
_Bug:_
throws an `ArgumentNullException `if the string `IsNullOrEmpty()`. I'd maybe understand a `null `check, but why would a `""` string be invalid for rendering as Raw? Anyway, the value, after being set, is used in only one place, which is being passed to `TextWriter.Write` function, which, according to [MSDN documentation](https://msdn.microsoft.com/en-us/library/cay30k2f%28v=vs.110%29.aspx?f=255&MSPPError=-2147217396), has no issues with `null`s (quote: "If value is null, nothing is written to the text stream.") This forces the user to check the contents of a string field on the `ViewModel `whenever calling the `Raw()` function just to avoid this `ArgumentNullException`, even though `TextWriter `would be completely fine with getting a `null `and would just ignore it.
_Fix:_
Changed the `IsNullOrEmpty `check to a regular `null `check. I feel like the check could be removed completely though, but I guess that would be more up to you and your coding guidelines.