### PR TITLE
Add ability to exclude assemblies from metadataReferences

### DIFF
--- a/src/RazorLight/EngineFactory.cs
+++ b/src/RazorLight/EngineFactory.cs
@@ -80,7 +80,7 @@ namespace RazorLight
 
             var sourceGenerator = new RazorSourceGenerator(DefaultRazorEngine.Instance, project, razorOptions.Namespaces);
 
-            var metadataReferenceManager = new DefaultMetadataReferenceManager(razorOptions.AdditionalMetadataReferences);
+            var metadataReferenceManager = new DefaultMetadataReferenceManager(razorOptions.AdditionalMetadataReferences, razorOptions.ExcludedAssemblies);
             var compiler = new RoslynCompilationService(metadataReferenceManager, Assembly.GetEntryAssembly());
             var templateFactoryProvider = new TemplateFactoryProvider(sourceGenerator, compiler, razorOptions);
 

--- a/src/RazorLight/RazorLightEngineBuilder.cs
+++ b/src/RazorLight/RazorLightEngineBuilder.cs
@@ -20,6 +20,8 @@ namespace RazorLight
 
         protected HashSet<MetadataReference> metadataReferences;
 
+        protected HashSet<string> excludedAssemblies;
+
         protected List<Action<ITemplatePage>> prerenderCallbacks;
 
         protected RazorLightProject project;
@@ -112,6 +114,22 @@ namespace RazorLight
             return this;
         }
 
+        public virtual RazorLightEngineBuilder ExcludeAssemblies(params string[] assemblyNames)
+        {
+            if (assemblyNames == null)
+            {
+                throw new ArgumentNullException(nameof(assemblyNames));
+            }
+
+            excludedAssemblies = new HashSet<string>();
+
+            foreach (var assemblyName in assemblyNames)
+            {
+                excludedAssemblies.Add(assemblyName);
+            }
+
+            return this;
+        }
         public virtual RazorLightEngineBuilder AddPrerenderCallbacks(params Action<ITemplatePage>[] callbacks)
         {
             if (callbacks == null)
@@ -168,13 +186,18 @@ namespace RazorLight
                 options.AdditionalMetadataReferences = metadataReferences;
             }
 
+            if (excludedAssemblies != null)
+            {
+                options.ExcludedAssemblies = excludedAssemblies;
+            }
+
             if (prerenderCallbacks != null)
             {
                 options.PreRenderCallbacks = prerenderCallbacks;
             }
 
             var sourceGenerator = new RazorSourceGenerator(DefaultRazorEngine.Instance, project, options.Namespaces);
-            var metadataReferenceManager = new DefaultMetadataReferenceManager(options.AdditionalMetadataReferences);
+            var metadataReferenceManager = new DefaultMetadataReferenceManager(options.AdditionalMetadataReferences, options.ExcludedAssemblies);
 
             var assembly = operatingAssembly ?? Assembly.GetEntryAssembly();
 

--- a/src/RazorLight/RazorLightOptions.cs
+++ b/src/RazorLight/RazorLightOptions.cs
@@ -2,6 +2,7 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System;
+using System.Reflection;
 
 namespace RazorLight
 {
@@ -12,7 +13,8 @@ namespace RazorLight
 			Namespaces = new HashSet<string>();
 			DynamicTemplates = new ConcurrentDictionary<string, string>();
 			AdditionalMetadataReferences = new HashSet<MetadataReference>();
-			PreRenderCallbacks = new List<Action<ITemplatePage>>();
+		    ExcludedAssemblies = new HashSet<string>();
+            PreRenderCallbacks = new List<Action<ITemplatePage>>();
 		}
 
 		public ISet<string> Namespaces { get; set; }
@@ -21,6 +23,8 @@ namespace RazorLight
 
 		public HashSet<MetadataReference> AdditionalMetadataReferences { get; set; }
 
-		public virtual IList<Action<ITemplatePage>> PreRenderCallbacks { get; set; }
+	    public HashSet<string> ExcludedAssemblies { get; set; }
+
+        public virtual IList<Action<ITemplatePage>> PreRenderCallbacks { get; set; }
 	}
 }

--- a/src/RazorLight/Text/RawString.cs
+++ b/src/RazorLight/Text/RawString.cs
@@ -24,9 +24,9 @@ namespace RazorLight.Text
         /// <param name="value">The value</param>
         public RawString(string value)
         {
-            if (value == null)
+            if (string.IsNullOrWhiteSpace(value))
             {
-                throw new ArgumentNullException(nameof(value));
+                _value = string.Empty;
             }
 
             _value = value;

--- a/tests/RazorLight.Tests/Compilation/DefaultMetadataReferenceManagerTest.cs
+++ b/tests/RazorLight.Tests/Compilation/DefaultMetadataReferenceManagerTest.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.CodeAnalysis;
 using Microsoft.Extensions.DependencyModel;
-using Moq;
 using RazorLight.Compilation;
 using System;
 using System.Collections.Generic;
@@ -14,7 +13,7 @@ namespace RazorLight.Tests.Compilation
         [Fact]
         public void Throws_OnEmptyManager_InConstructor()
         {
-            Assert.Throws<ArgumentNullException>(() => { new DefaultMetadataReferenceManager(null); });
+            Assert.Throws<ArgumentNullException>(() => { new DefaultMetadataReferenceManager(null, null); });
         }
 
         [Fact]
@@ -40,9 +39,9 @@ namespace RazorLight.Tests.Compilation
             Exception ex = null;
             try
             {
-                PoseContext.Isolate(() => 
+                PoseContext.Isolate(() =>
                 {
-                    manager.Resolve(DependencyContext.Default);
+                    manager.Resolve(null, DependencyContext.Default);
                 }, classPropShim);
 
             }
@@ -56,5 +55,5 @@ namespace RazorLight.Tests.Compilation
             Assert.Equal(ex.Message, "Can't load metadata reference from the entry assembly. " +
                     "Make sure PreserveCompilationContext is set to true in *.csproj file");
         }
-	}
+    }
 }


### PR DESCRIPTION
There are some cases where assemblies cannot be loaded even by providing the
additional metadata reference.  They usually aren't needed anyway, and this provides
for a mechanism to exclude them.

I wanted to add a test for this, but was not able to replicate the behavior I was seeing a real project in the test project. 