### PR TITLE
Nice exception when no RazorProject specified

### DIFF
--- a/src/RazorLight/Compilation/RazorTemplateCompiler.cs
+++ b/src/RazorLight/Compilation/RazorTemplateCompiler.cs
@@ -116,7 +116,7 @@ namespace RazorLight.Compilation
 				// At this point, we've decided what to do - but we should create the cache entry and
 				// release the lock first.
 				cacheEntryOptions = new MemoryCacheEntryOptions();
-				if(item.ExpirationToken != null)
+				if(item?.ExpirationToken != null)
 				{
 					cacheEntryOptions.ExpirationTokens.Add(item.ExpirationToken);
 				}

--- a/src/RazorLight/RazorLightEngineBuilder.cs
+++ b/src/RazorLight/RazorLightEngineBuilder.cs
@@ -30,12 +30,7 @@ namespace RazorLight
 
         public virtual RazorLightEngineBuilder UseProject(RazorLightProject project)
         {
-            if (project == null)
-            {
-                throw new ArgumentNullException(nameof(project));
-            }
-
-            this.project = project;
+            this.project = project ?? throw new ArgumentNullException(nameof(project));
 
             return this;
         }
@@ -177,6 +172,9 @@ namespace RazorLight
 
         public virtual RazorLightEngine Build()
         {
+            if(project == null)
+                throw new RazorLightProjectIsNotSpecified();
+            
             var options = new RazorLightOptions();
 
             if (namespaces != null)
@@ -209,12 +207,11 @@ namespace RazorLight
 				options.CachingProvider = cachingProvider;
 			}
 
-
             var metadataReferenceManager = new DefaultMetadataReferenceManager(options.AdditionalMetadataReferences, options.ExcludedAssemblies);
             var assembly = operatingAssembly ?? Assembly.GetEntryAssembly();
             var compiler = new RoslynCompilationService(metadataReferenceManager, assembly);
-
-			var sourceGenerator = new RazorSourceGenerator(DefaultRazorEngine.Instance, project, options.Namespaces);
+            
+            var sourceGenerator = new RazorSourceGenerator(DefaultRazorEngine.Instance, project, options.Namespaces);
 			var templateCompiler = new RazorTemplateCompiler(sourceGenerator, compiler, project, options);
 			var templateFactoryProvider = new TemplateFactoryProvider();
 

--- a/src/RazorLight/RazorLightProjectIsNotSpecified.cs
+++ b/src/RazorLight/RazorLightProjectIsNotSpecified.cs
@@ -1,0 +1,10 @@
+﻿namespace RazorLight
+{
+    public class RazorLightProjectIsNotSpecified : RazorLightException
+    {
+        public RazorLightProjectIsNotSpecified(string message =
+            "There is no project specified to use with builder. You have to specify it before build") : base(message)
+        {
+        }
+    }
+}


### PR DESCRIPTION
I believe that is make sense to give users nice exception when no RazorProject specified to use with builder instead confusing ArgumentNullException from deep.
That might be kind of https://github.com/toddams/RazorLight/issues/200 solution.