### PR TITLE
Fixed key not used & fixed typo.

### DIFF
--- a/src/RazorLight/Generation/RazorSourceGenerator.cs
+++ b/src/RazorLight/Generation/RazorSourceGenerator.cs
@@ -47,8 +47,8 @@ namespace RazorLight.Generation
 
 			if(Project == null)
 			{
-				string _message = "Can not resolve a content for the template \"{0}\" as there is no project set." +
-					"You can only render a template by passing it's content directly via string using coresponding function overload";
+				string _message = $"Can not resolve a content for the template \"{key}\" as there is no project set. " +
+					"You can only render a template by passing it's content directly via string using corresponding function overload";
 
 				throw new InvalidOperationException(_message);
 			}

--- a/tests/RazorLight.Tests/Generation/RazorSourceGeneratorTest.cs
+++ b/tests/RazorLight.Tests/Generation/RazorSourceGeneratorTest.cs
@@ -120,13 +120,14 @@ namespace RazorLight.Tests
 
 
         [Fact]
-        public void GenerateCode_ByKey_Throws_OnEmpty_Project()
+        public async void GenerateCode_ByKey_Throws_OnEmpty_Project()
         {
             var generator = new RazorSourceGenerator(DefaultRazorEngine.Instance, project: null);
 
             Func<Task> action = () => generator.GenerateCodeAsync("key");
 
-            Assert.ThrowsAsync<InvalidOperationException>(action);
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(action);
+            Assert.Equal("Can not resolve a content for the template \"key\" as there is no project set. You can only render a template by passing it's content directly via string using corresponding function overload", exception.Message);
         }
     }
 }

--- a/tests/RazorLight.Tests/Generation/RazorSourceGeneratorTest.cs
+++ b/tests/RazorLight.Tests/Generation/RazorSourceGeneratorTest.cs
@@ -120,7 +120,7 @@ namespace RazorLight.Tests
 
 
         [Fact]
-        public async void GenerateCode_ByKey_Throws_OnEmpty_Project()
+        public async Task GenerateCode_ByKey_Throws_OnEmpty_Project()
         {
             var generator = new RazorSourceGenerator(DefaultRazorEngine.Instance, project: null);
 


### PR DESCRIPTION
Hey there,

This PR attempts to solve the following issue: when unable to load a template the error message doesn't display the template name but a `{0}` placeholder.

Here is an example of error:
```console
System.Exception : Error during generating email for purchase order e49bdfed-6d70-4de4-8ecd-02477600519e.
---- System.InvalidOperationException : Can not resolve a content for the template "{0}" as there is no project set.You can only render a template by passing it's content directly via string using coresponding function overload
```
I fixed a typo in the meantinme.

Message is now like below
```console
Can not resolve a content for the template \"key\" as there is no project set. You can only render a template by passing it's content directly via string using corresponding function overload
```

Cheers,
Olivier