### PR TITLE
Add option to builder to globally disable encoding.

### DIFF
--- a/src/RazorLight/EngineHandler.cs
+++ b/src/RazorLight/EngineHandler.cs
@@ -59,7 +59,9 @@ namespace RazorLight
 				templateDescriptor.ExpirationToken);
 			}
 
-			return templateFactory();
+			ITemplatePage templatePage = templateFactory();
+			templatePage.DisableEncoding = Options.DisableEncoding;
+			return templatePage;
 		}
 
 		/// <summary>

--- a/src/RazorLight/RazorLightEngineBuilder.cs
+++ b/src/RazorLight/RazorLightEngineBuilder.cs
@@ -28,6 +28,8 @@ namespace RazorLight
 
         protected ICachingProvider cachingProvider;
 
+        private bool disableEncoding = false;
+
         public virtual RazorLightEngineBuilder UseProject(RazorLightProject project)
         {
             if (project == null)
@@ -46,6 +48,45 @@ namespace RazorLight
 
             return this;
         }
+
+
+		/// <summary>
+		/// Disables encoding of HTML entities in variables.
+		/// </summary>
+		/// <example>
+		/// The model contais a property with value "&gt;hello&lt;".
+		/// 
+		/// In the rendered template this will be:
+		/// 
+		/// <code>
+		/// &gt;hello&lt;
+		/// </code>
+		/// </example>
+		/// <returns>A <see cref="RazorLightEngineBuilder"/></returns>
+		public RazorLightEngineBuilder DisableEncoding()
+		{
+			disableEncoding = true;
+			return this;
+		}
+
+		/// <summary>
+		/// Enables encoding of HTML entities in variables.
+		/// </summary>
+		/// <example>
+		/// The model contais a property with value "&gt;hello&lt;".
+		/// 
+		/// In the rendered template this will be:
+		/// 
+		/// <code>
+		/// &amp;gt;hello&amp;lt;
+		/// </code>
+		/// </example>
+		/// <returns>A <see cref="RazorLightEngineBuilder"/></returns>
+		public RazorLightEngineBuilder EnableEncoding()
+		{
+			disableEncoding = false;
+			return this;
+		}
 
 		public RazorLightEngineBuilder UseEmbeddedResourcesProject(Assembly assembly, string rootNamespace = null)
 		{
@@ -208,6 +249,8 @@ namespace RazorLight
 			{
 				options.CachingProvider = cachingProvider;
 			}
+
+            options.DisableEncoding = disableEncoding;
 
 
             var metadataReferenceManager = new DefaultMetadataReferenceManager(options.AdditionalMetadataReferences, options.ExcludedAssemblies);

--- a/src/RazorLight/RazorLightOptions.cs
+++ b/src/RazorLight/RazorLightOptions.cs
@@ -13,8 +13,9 @@ namespace RazorLight
 			Namespaces = new HashSet<string>();
 			DynamicTemplates = new ConcurrentDictionary<string, string>();
 			AdditionalMetadataReferences = new HashSet<MetadataReference>();
-		    ExcludedAssemblies = new HashSet<string>();
-            PreRenderCallbacks = new List<Action<ITemplatePage>>();
+			ExcludedAssemblies = new HashSet<string>();
+			PreRenderCallbacks = new List<Action<ITemplatePage>>();
+			DisableEncoding = false;
 		}
 
 		public ISet<string> Namespaces { get; set; }
@@ -23,10 +24,17 @@ namespace RazorLight
 
 		public HashSet<MetadataReference> AdditionalMetadataReferences { get; set; }
 
-	    public HashSet<string> ExcludedAssemblies { get; set; }
+		public HashSet<string> ExcludedAssemblies { get; set; }
 
-        public virtual IList<Action<ITemplatePage>> PreRenderCallbacks { get; set; }
+		public virtual IList<Action<ITemplatePage>> PreRenderCallbacks { get; set; }
 
 		public ICachingProvider CachingProvider { get; set; }
+
+		/// <summary>
+		/// Settings this to <c>true</c> will disable HTML encoding in all templates.
+		/// It can be reenabled by setting <c>DisableEncoding = false</c> in the
+		/// template.
+		/// </summary>
+		public bool DisableEncoding { get; set; }
 	}
 }

--- a/tests/RazorLight.Tests/RazorLightEngineTest.cs
+++ b/tests/RazorLight.Tests/RazorLightEngineTest.cs
@@ -1,19 +1,36 @@
-﻿using System.Threading.Tasks;
-using RazorLight.Razor;
-using RazorLight.Tests.Razor;
-using Xunit;
-using RazorLight.Compilation;
-using Moq;
-using RazorLight.Caching;
-using System;
-
-namespace RazorLight.Tests
+﻿namespace RazorLight.Tests
 {
-    public class RazorLightEngineTest
-    {
-        //TODO: add string rendering test
+	using System.Threading.Tasks;
+	using Xunit;
 
-  //      [Fact]
+	public class RazorLightEngineTest
+	{
+
+		[Fact]
+		public async Task Ensure_Option_DisablEncoding_Renders_Models_Raw()
+		{
+			//Assing
+			var engine = new RazorLightEngineBuilder()
+				.UseMemoryCachingProvider()
+				.UseFileSystemProject(DirectoryUtils.RootDirectory)
+				.DisableEncoding()
+				.Build();
+
+			string key = "key";
+			string content = "@Model.Entity";
+
+			var model = new { Entity = "<pre></pre>" };
+
+			// act
+			var result = await engine.CompileRenderStringAsync(key, content, model);
+
+			// assert
+			Assert.Contains("<pre></pre>", result);
+		}
+
+		//TODO: add string rendering test
+
+		//      [Fact]
 		//public async Task Ensure_Content_Added_To_DynamicTemplates()
 		//{
 		//	var options = new RazorLightOptions();


### PR DESCRIPTION
This is very conventient when you are using the engine
to generate other things then HTML pages.
For example C# code.