### PR TITLE
Add netcore 3.0 support

### DIFF
--- a/samples/RazorLight.Samples/Program.cs
+++ b/samples/RazorLight.Samples/Program.cs
@@ -26,7 +26,11 @@ namespace Samples.EntityFrameworkProject
             // As our key in database is integer, but engine takes string as a key - pass integer ID as a string
             string templateKey = "2";
             var model = new TestViewModel() { Name = "Johny", Age = 22 };
-            string result = engine.CompileRenderAsync(templateKey, model).Result;
+
+#if NETCOREAPP3_0
+			model.Age = 40;
+#endif
+			string result = engine.CompileRenderAsync(templateKey, model).Result;
 
             //Identation will be a bit fuzzy, as we formatted a string for readability
             Console.WriteLine(result);

--- a/samples/RazorLight.Samples/Samples.EntityFrameworkProject.csproj
+++ b/samples/RazorLight.Samples/Samples.EntityFrameworkProject.csproj
@@ -1,14 +1,19 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;netcoreapp3.0</TargetFrameworks>
     <PreserveCompilationContext>true</PreserveCompilationContext>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/RazorLight.Precompile/RazorLight.Precompile.csproj
+++ b/src/RazorLight.Precompile/RazorLight.Precompile.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/RazorLight/DefaultRazorEngine.cs
+++ b/src/RazorLight/DefaultRazorEngine.cs
@@ -17,15 +17,20 @@ namespace RazorLight
 					Instrumentation.InjectDirective.Register(builder);
 					Instrumentation.ModelDirective.Register(builder);
 
+#if NETSTANDARD2_0
+
 					NamespaceDirective.Register(builder);
 					FunctionsDirective.Register(builder);
 					InheritsDirective.Register(builder);
 					SectionDirective.Register(builder);
+#endif 
 
 					builder.Features.Add(new ModelExpressionPass());
 					builder.Features.Add(new RazorLightTemplateDocumentClassifierPass());
 					builder.Features.Add(new RazorLightAssemblyAttributeInjectionPass());
+#if NETSTANDARD2_0
 					builder.Features.Add(new InstrumentationPass());
+#endif
 					//builder.Features.Add(new ViewComponentTagHelperPass());
 
 					builder.AddTargetExtension(new TemplateTargetExtension()
@@ -47,10 +52,21 @@ namespace RazorLight
 				throw new System.NotImplementedException();
 			}
 
+
+#if NETCOREAPP3_0
+			[System.Obsolete]
+#endif
 			public override RazorProjectItem GetItem(string path)
 			{
 				throw new System.NotImplementedException();
 			}
+
+#if NETCOREAPP3_0
+			public override RazorProjectItem GetItem(string path, string fileKind)
+			{
+				throw new System.NotImplementedException();
+			}
+#endif
 		}
 	}
 }

--- a/src/RazorLight/DefaultRazorEngine.cs
+++ b/src/RazorLight/DefaultRazorEngine.cs
@@ -8,58 +8,61 @@ namespace RazorLight
 {
     internal sealed class DefaultRazorEngine
     {
-		public static RazorEngine Instance
-		{
-			get
-			{
-				var razorProjectEngine = RazorProjectEngine.Create(RazorConfiguration.Default, new NullRazorProjectFileSystem() , builder =>
-				{
-					Instrumentation.InjectDirective.Register(builder);
-					Instrumentation.ModelDirective.Register(builder);
+        public static RazorEngine Instance
+        {
+            get
+            {
+                var configuration = RazorConfiguration.Default;
+                var razorProjectEngine = RazorProjectEngine.Create(configuration, new NullRazorProjectFileSystem(), builder =>
+               {
+                   Instrumentation.InjectDirective.Register(builder);
+                   Instrumentation.ModelDirective.Register(builder);
 
-#if NETSTANDARD2_0
+				   //In RazorLanguageVersion > 3.0 (at least netcore 3.0) the directives are registed out of the box.
+                   if (!RazorLanguageVersion.TryParse("3.0", out var razorLanguageVersion) 
+					   || configuration.LanguageVersion.CompareTo(razorLanguageVersion) < 0)
+                   {
+                       NamespaceDirective.Register(builder);
+                       FunctionsDirective.Register(builder);
+                       InheritsDirective.Register(builder);
+                       SectionDirective.Register(builder);
+                   }
 
-					NamespaceDirective.Register(builder);
-					FunctionsDirective.Register(builder);
-					InheritsDirective.Register(builder);
-					SectionDirective.Register(builder);
-#endif 
-
-					builder.Features.Add(new ModelExpressionPass());
-					builder.Features.Add(new RazorLightTemplateDocumentClassifierPass());
-					builder.Features.Add(new RazorLightAssemblyAttributeInjectionPass());
+                   builder.Features.Add(new ModelExpressionPass());
+                   builder.Features.Add(new RazorLightTemplateDocumentClassifierPass());
+                   builder.Features.Add(new RazorLightAssemblyAttributeInjectionPass());
 #if NETSTANDARD2_0
 					builder.Features.Add(new InstrumentationPass());
 #endif
-					//builder.Features.Add(new ViewComponentTagHelperPass());
+                    //builder.Features.Add(new ViewComponentTagHelperPass());
 
-					builder.AddTargetExtension(new TemplateTargetExtension()
-					{
-						TemplateTypeName = "global::RazorLight.Razor.RazorLightHelperResult",
-					});
+                    builder.AddTargetExtension(new TemplateTargetExtension()
+                   {
+                       TemplateTypeName = "global::RazorLight.Razor.RazorLightHelperResult",
+                   });
 
-					OverrideRuntimeNodeWriterTemplateTypeNamePhase.Register(builder);
-				});
+                   OverrideRuntimeNodeWriterTemplateTypeNamePhase.Register(builder);
+               });
 
-				return razorProjectEngine.Engine;
-			}
-		}
+                return razorProjectEngine.Engine;
+            }
+        }
 
-		private class NullRazorProjectFileSystem : RazorProjectFileSystem
-		{
-			public override IEnumerable<RazorProjectItem> EnumerateItems(string basePath)
-			{
-				throw new System.NotImplementedException();
-			}
+        private class NullRazorProjectFileSystem : RazorProjectFileSystem
+        {
+            public override IEnumerable<RazorProjectItem> EnumerateItems(string basePath)
+            {
+                throw new System.NotImplementedException();
+            }
 
 
 #if NETCOREAPP3_0
 			[System.Obsolete]
 #endif
-			public override RazorProjectItem GetItem(string path)
-			{
-				throw new System.NotImplementedException();
-			}
+            public override RazorProjectItem GetItem(string path)
+            {
+                throw new System.NotImplementedException();
+            }
 
 #if NETCOREAPP3_0
 			public override RazorProjectItem GetItem(string path, string fileKind)
@@ -67,6 +70,6 @@ namespace RazorLight
 				throw new System.NotImplementedException();
 			}
 #endif
-		}
-	}
+        }
+    }
 }

--- a/src/RazorLight/RazorLight.csproj
+++ b/src/RazorLight/RazorLight.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
-
+    
   <PropertyGroup>
     <PackageId>RazorLight</PackageId>
     <Title>RazorLight</Title>
@@ -13,7 +13,7 @@
     <RepositoryUrl>https://github.com/toddams/RazorLight</RepositoryUrl>
   </PropertyGroup>
   
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.CodeAnalysis.Razor" Version="2.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Html.Abstractions" Version="2.1.0" />
@@ -26,6 +26,19 @@
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.Primitives" Version="2.1.0" />
+    <PackageReference Include="System.Buffers" Version="4.5.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="3.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Razor" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Primitives" Version="3.0.0" />
     <PackageReference Include="System.Buffers" Version="4.5.0" />
   </ItemGroup>
 </Project>

--- a/tests/RazorLight.Tests/RazorLight.Tests.csproj
+++ b/tests/RazorLight.Tests/RazorLight.Tests.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;netcoreapp3.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <DefineConstants>$(DefineConstants);SOME_TEST_DEFINE</DefineConstants>
-    <LangVersion>7</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -29,14 +29,21 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="Moq" Version="4.7.99" />
     <PackageReference Include="Pose" Version="1.2.1" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.1.0" />
+  </ItemGroup>
+  
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="3.0.0" />
+  </ItemGroup>
+  
   <ItemGroup>
     <ProjectReference Include="..\..\src\RazorLight\RazorLight.csproj" />
   </ItemGroup>


### PR DESCRIPTION
This PR adds supports for .net core 3.0 , in addition to netstandard 2.0 (multi framework)

All unit tests run both .net core 3.0 and .net core 2.0 tests, and all pass.

Fixes #258
Implements #267 
Replaces #274 
