### PR TITLE
Include xml docs & snupkg debug package

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,3 +4,7 @@ root = true
 # Tab indentation
 [*.{cs,cshtml}]
 indent_style = tab
+[*.cs]
+
+# CS1591: Missing XML comment for publicly visible type or member
+dotnet_diagnostic.CS1591.severity = none

--- a/src/RazorLight/RazorLight.csproj
+++ b/src/RazorLight/RazorLight.csproj
@@ -11,6 +11,9 @@
     <Authors>toddams</Authors>
     <PackageTags>RazorLight, razor, render, dotnet-core, dotnet, core, template-engine, email, emails</PackageTags>
     <RepositoryUrl>https://github.com/toddams/RazorLight</RepositoryUrl>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <IncludeSymbols>true</IncludeSymbols>
   </PropertyGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">

--- a/src/RazorLight/RazorLight.csproj
+++ b/src/RazorLight/RazorLight.csproj
@@ -12,8 +12,6 @@
     <PackageTags>RazorLight, razor, render, dotnet-core, dotnet, core, template-engine, email, emails</PackageTags>
     <RepositoryUrl>https://github.com/toddams/RazorLight</RepositoryUrl>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <IncludeSymbols>true</IncludeSymbols>
   </PropertyGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">

--- a/src/RazorLight/RazorLight.csproj
+++ b/src/RazorLight/RazorLight.csproj
@@ -12,6 +12,8 @@
     <PackageTags>RazorLight, razor, render, dotnet-core, dotnet, core, template-engine, email, emails</PackageTags>
     <RepositoryUrl>https://github.com/toddams/RazorLight</RepositoryUrl>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <IncludeSymbols>true</IncludeSymbols>
   </PropertyGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">


### PR DESCRIPTION
Build will now produce an XML documentation file which will be picked up during pack (editorconfig amendment is needed  because MSBuild started to complain that all public types miss documentation). I also set the Symbol package format to snupkg - this is a new format which is supported by nuget.org. It will generate a *.snupkg package which will automatically be picked up by nuget push.

Resolves #285