### PR TITLE
Fixes #287: Make TemplateRenderer stateless 

### DIFF
--- a/src/RazorLight/EngineHandler.cs
+++ b/src/RazorLight/EngineHandler.cs
@@ -100,8 +100,8 @@ namespace RazorLight
 
 			using (var scope = new MemoryPoolViewBufferScope())
 			{
-				var renderer = new TemplateRenderer(templatePage, this, HtmlEncoder.Default, scope);
-				await renderer.RenderAsync().ConfigureAwait(false);
+				var renderer = new TemplateRenderer(this, HtmlEncoder.Default, scope);
+				await renderer.RenderAsync(templatePage).ConfigureAwait(false);
 			}
 		}
 
@@ -113,9 +113,7 @@ namespace RazorLight
 			TemplateRenderer templateRenderer)
 		{
 			SetModelContext(templatePage, textWriter, model, viewBag);
-
-			templateRenderer.RazorPage = templatePage;
-			await templateRenderer.RenderAsync().ConfigureAwait(false);
+			await templateRenderer.RenderAsync(templatePage).ConfigureAwait(false);
 		}
 
 		/// <summary>

--- a/src/RazorLight/TemplateRenderer.cs
+++ b/src/RazorLight/TemplateRenderer.cs
@@ -15,21 +15,14 @@ namespace RazorLight
         private readonly IViewBufferScope _bufferScope;
 
         public TemplateRenderer(
-            ITemplatePage razorPage,
 			IEngineHandler engineHandler,
             HtmlEncoder htmlEncoder,
 			IViewBufferScope bufferScope)
         {
-            RazorPage = razorPage ?? throw new ArgumentNullException(nameof(razorPage));
 			_engineHandler = engineHandler ?? throw new ArgumentNullException(nameof(engineHandler));
 			_bufferScope = bufferScope ?? throw new ArgumentNullException(nameof(bufferScope));
 			_htmlEncoder = htmlEncoder ?? throw new ArgumentNullException(nameof(htmlEncoder));
         }
-
-        /// <summary>
-        /// Gets <see cref="ITemplatePage"/> instance that the views executes on.
-        /// </summary>
-        public ITemplatePage RazorPage { get; set; }
 
         ///// <summary>
         ///// Gets the sequence of _ViewStart <see cref="ITemplatePage"/> instances that are executed by this view.
@@ -37,12 +30,12 @@ namespace RazorLight
         //public IReadOnlyList<ITemplatePage> ViewStartPages { get; }
 
         /// <inheritdoc />
-        public virtual async Task RenderAsync()
+        public virtual async Task RenderAsync(ITemplatePage page)
         {
-            var context = RazorPage.PageContext;
+            var context = page.PageContext;
 
-            var bodyWriter = await RenderPageAsync(RazorPage, context, invokeViewStarts: false).ConfigureAwait(false);
-            await RenderLayoutAsync(context, bodyWriter).ConfigureAwait(false);
+            var bodyWriter = await RenderPageAsync(page, context, invokeViewStarts: false).ConfigureAwait(false);
+            await RenderLayoutAsync(page, context, bodyWriter).ConfigureAwait(false);
         }
 
         private async Task<ViewBufferTextWriter> RenderPageAsync(
@@ -152,12 +145,13 @@ namespace RazorLight
         }
 
         private async Task RenderLayoutAsync(
-            PageContext context,
+	        ITemplatePage page,
+			PageContext context,
             ViewBufferTextWriter bodyWriter)
         {
             // A layout page can specify another layout page. We'll need to continue
             // looking for layout pages until they're no longer specified.
-            var previousPage = RazorPage;
+            var previousPage = page;
             var renderedLayouts = new List<ITemplatePage>();
 
             // This loop will execute Layout pages from the inside to the outside. With each

--- a/tests/RazorLight.Tests/TemplateRendererTest.cs
+++ b/tests/RazorLight.Tests/TemplateRendererTest.cs
@@ -31,8 +31,8 @@ namespace RazorLight.Tests
 			engineMock.SetupGet(e => e.Options).Returns(options);
 
 			//Act
-			var templateRenderer = new TemplateRenderer(page, engineMock.Object, HtmlEncoder.Default, new MemoryPoolViewBufferScope());
-			await templateRenderer.RenderAsync();
+			var templateRenderer = new TemplateRenderer(engineMock.Object, HtmlEncoder.Default, new MemoryPoolViewBufferScope());
+			await templateRenderer.RenderAsync(page);
 
 			//Assert
 			Assert.True(triggered1);
@@ -84,8 +84,8 @@ namespace RazorLight.Tests
 			using (var writer = new StringWriter())
 			{
 				page.PageContext.Writer = writer;
-				var renderer = new TemplateRenderer(page, engineMock.Object, encoder, new MemoryPoolViewBufferScope());
-				await renderer.RenderAsync();
+				var renderer = new TemplateRenderer(engineMock.Object, encoder, new MemoryPoolViewBufferScope());
+				await renderer.RenderAsync(page);
 
 				output = writer.ToString();
 			}


### PR DESCRIPTION
This was my suggestion to make the TemplateRenderer stateless to avoid the issues that caused the failure of Layout to be rendered when using await IncludeAsync: https://github.com/toddams/RazorLight/issues/287