### PR TITLE
Creating DI Extension + .NET Framework assembly directory format fix

### DIFF
--- a/src/RazorLight/Compilation/DefaultAssemblyDirectoryFormatter.cs
+++ b/src/RazorLight/Compilation/DefaultAssemblyDirectoryFormatter.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+
+namespace RazorLight.Compilation
+{
+	public class DefaultAssemblyDirectoryFormatter : IAssemblyDirectoryFormatter
+	{
+		public string GetAssemblyDirectory(Assembly assembly)
+		{
+			string codeBase = assembly.CodeBase;
+			UriBuilder uri = new UriBuilder(codeBase);
+			return Uri.UnescapeDataString(uri.Path);
+		}
+	}
+}

--- a/src/RazorLight/Compilation/DefaultMetadataReferenceManager.cs
+++ b/src/RazorLight/Compilation/DefaultMetadataReferenceManager.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.DependencyModel;
 using System.Linq;
 using System.IO;
 using System.Reflection.PortableExecutable;
+using Microsoft.Extensions.Options;
 
 namespace RazorLight.Compilation
 {
@@ -19,6 +20,11 @@ namespace RazorLight.Compilation
 		{
 			AdditionalMetadataReferences = new HashSet<MetadataReference>();
 			ExcludedAssemblies = new HashSet<string>();
+		}
+
+		public DefaultMetadataReferenceManager(IOptions<RazorLightOptions> options) : this(options.Value.AdditionalMetadataReferences, options.Value.ExcludedAssemblies)
+		{
+			
 		}
 
 		public DefaultMetadataReferenceManager(HashSet<MetadataReference> metadataReferences)

--- a/src/RazorLight/Compilation/DefaultMetadataReferenceManager.cs
+++ b/src/RazorLight/Compilation/DefaultMetadataReferenceManager.cs
@@ -13,6 +13,7 @@ namespace RazorLight.Compilation
 {
 	public class DefaultMetadataReferenceManager : IMetadataReferenceManager
 	{
+		private IAssemblyDirectoryFormatter _directoryFormatter = new DefaultAssemblyDirectoryFormatter();
 		public HashSet<MetadataReference> AdditionalMetadataReferences { get; }
 		public HashSet<string> ExcludedAssemblies { get; }
 
@@ -22,9 +23,9 @@ namespace RazorLight.Compilation
 			ExcludedAssemblies = new HashSet<string>();
 		}
 
-		public DefaultMetadataReferenceManager(IOptions<RazorLightOptions> options) : this(options.Value.AdditionalMetadataReferences, options.Value.ExcludedAssemblies)
+		public DefaultMetadataReferenceManager(IOptions<RazorLightOptions> options, IAssemblyDirectoryFormatter directoryFormatter) : this(options.Value.AdditionalMetadataReferences, options.Value.ExcludedAssemblies)
 		{
-			
+			_directoryFormatter = directoryFormatter;
 		}
 
 		public DefaultMetadataReferenceManager(HashSet<MetadataReference> metadataReferences)
@@ -54,7 +55,7 @@ namespace RazorLight.Compilation
 			{
 				var context = new HashSet<string>();
 				var x = GetReferencedAssemblies(assembly, ExcludedAssemblies, context).Union(new Assembly[] { assembly }).ToArray();
-				references = x.Select(p => AssemblyDirectory(p));
+				references = x.Select(p => _directoryFormatter.GetAssemblyDirectory(p));
 			}
 			else
 			{
@@ -114,11 +115,6 @@ namespace RazorLight.Compilation
 			}
 		}
 
-		private static string AssemblyDirectory(Assembly assembly)
-		{
-			string codeBase = assembly.CodeBase;
-			UriBuilder uri = new UriBuilder(codeBase);
-			return Uri.UnescapeDataString(uri.Path);
-		}
+	
 	}
 }

--- a/src/RazorLight/Compilation/IAssemblyDirectoryFormatter.cs
+++ b/src/RazorLight/Compilation/IAssemblyDirectoryFormatter.cs
@@ -1,0 +1,9 @@
+﻿using System.Reflection;
+
+namespace RazorLight.Compilation
+{
+	public interface IAssemblyDirectoryFormatter
+	{
+		string GetAssemblyDirectory(Assembly assembly);
+	}
+}

--- a/src/RazorLight/Compilation/LegacyFixAssemblyDirectoryFormatter.cs
+++ b/src/RazorLight/Compilation/LegacyFixAssemblyDirectoryFormatter.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+
+namespace RazorLight.Compilation
+{
+	public class LegacyFixAssemblyDirectoryFormatter : IAssemblyDirectoryFormatter
+	{
+		public string GetAssemblyDirectory(Assembly assembly)
+		{
+			string codeBase = assembly.CodeBase;
+			UriBuilder uriBuilder = new UriBuilder(codeBase);
+			string assemlbyDirectory = Uri.UnescapeDataString(uriBuilder.Path + uriBuilder.Fragment);
+			return assemlbyDirectory;
+		}
+	}
+}

--- a/src/RazorLight/Compilation/RazorTemplateCompiler.cs
+++ b/src/RazorLight/Compilation/RazorTemplateCompiler.cs
@@ -19,7 +19,7 @@ namespace RazorLight.Compilation
 		private readonly object _cacheLock = new object();
 
 		private RazorSourceGenerator _razorSourceGenerator;
-		private RoslynCompilationService _compiler;
+		private ICompilationService _compiler;
 
 		private readonly RazorLightOptions _razorLightOptions;
 		private readonly RazorLightProject _razorProject;
@@ -29,12 +29,12 @@ namespace RazorLight.Compilation
 
 		public RazorTemplateCompiler(
 			RazorSourceGenerator sourceGenerator,
-			RoslynCompilationService roslynCompilationService,
+			ICompilationService compilationService,
 			RazorLightProject razorLightProject,
 			RazorLightOptions razorLightOptions)
 		{
 			_razorSourceGenerator = sourceGenerator ?? throw new ArgumentNullException(nameof(sourceGenerator));
-			_compiler = roslynCompilationService ?? throw new ArgumentNullException(nameof(roslynCompilationService));
+			_compiler = compilationService ?? throw new ArgumentNullException(nameof(compilationService));
 			_razorProject = razorLightProject ?? throw new ArgumentNullException(nameof(razorLightProject));
 			_razorLightOptions = razorLightOptions ?? throw new ArgumentNullException(nameof(razorLightOptions));
 
@@ -52,6 +52,15 @@ namespace RazorLight.Compilation
 			_precompiledViews = new Dictionary<string, CompiledTemplateDescriptor>(
 				5, //Change capacity when precompiled views are arrived
 				StringComparer.OrdinalIgnoreCase);
+		}
+
+		public RazorTemplateCompiler(
+			RazorSourceGenerator sourceGenerator,
+			ICompilationService compilationService,
+			RazorLightProject razorLightProject,
+			IOptions<RazorLightOptions> options) : this(sourceGenerator, compilationService, razorLightProject, options.Value)
+		{
+
 		}
 
 		public ICompilationService CompilationService => _compiler;

--- a/src/RazorLight/Compilation/RoslynCompilationService.cs
+++ b/src/RazorLight/Compilation/RoslynCompilationService.cs
@@ -41,6 +41,11 @@ namespace RazorLight.Compilation
 			EmitOptions = new EmitOptions(debugInformationFormat: pdbFormat);
 		}
 
+		public RoslynCompilationService(IMetadataReferenceManager referenceManager, IOptions<RazorLightOptions> options) :this(referenceManager,options.Value.OperatingAssemlby)
+		{
+			
+		}
+
 		#region Options
 
 		public virtual Assembly OperatingAssembly

--- a/src/RazorLight/Compilation/RoslynCompilationService.cs
+++ b/src/RazorLight/Compilation/RoslynCompilationService.cs
@@ -41,7 +41,7 @@ namespace RazorLight.Compilation
 			EmitOptions = new EmitOptions(debugInformationFormat: pdbFormat);
 		}
 
-		public RoslynCompilationService(IMetadataReferenceManager referenceManager, IOptions<RazorLightOptions> options) :this(referenceManager,options.Value.OperatingAssemlby)
+		public RoslynCompilationService(IMetadataReferenceManager referenceManager, IOptions<RazorLightOptions> options) :this(referenceManager,options.Value.OperatingAssembly)
 		{
 			
 		}

--- a/src/RazorLight/EngineHandler.cs
+++ b/src/RazorLight/EngineHandler.cs
@@ -3,6 +3,7 @@ using System.Dynamic;
 using System.IO;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
 using RazorLight.Caching;
 using RazorLight.Compilation;
 using RazorLight.Internal;
@@ -22,6 +23,16 @@ namespace RazorLight
 			FactoryProvider = factoryProvider ?? throw new ArgumentNullException(nameof(factoryProvider));
 
 			Cache = cache;
+		}
+
+		public EngineHandler(
+			IOptions<RazorLightOptions> options,
+			IRazorTemplateCompiler compiler,
+			ITemplateFactoryProvider factoryProvider,
+			ICachingProvider cache) : this(options.Value, compiler, factoryProvider, cache)
+		{
+			
+
 		}
 
 		public RazorLightOptions Options { get; }

--- a/src/RazorLight/Extensions/ServiceCollectionExtensions.cs
+++ b/src/RazorLight/Extensions/ServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Reflection;
+using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -39,9 +40,13 @@ namespace RazorLight.Extensions
 		public static RazorLightDependencyBuilder AddRazorLight(this IServiceCollection services)
 		{
 			services = services ?? throw new ArgumentNullException(nameof(services));
-
+			services.AddOptions().Configure<RazorLightOptions>((options) => 
+			{
+				options.OperatingAssembly = options.OperatingAssembly ?? Assembly.GetEntryAssembly();
+			});
 			services.TryAddSingleton<PropertyInjector>();
 			services.TryAddSingleton<ICachingProvider, MemoryCachingProvider>();
+			services.TryAddSingleton<RazorEngine>(DefaultRazorEngine.Instance);
 			services.TryAddSingleton<RazorSourceGenerator>();
 			services.TryAddSingleton<IRazorTemplateCompiler, RazorTemplateCompiler>();
 			services.TryAddSingleton<ITemplateFactoryProvider, TemplateFactoryProvider>();			

--- a/src/RazorLight/Extensions/ServiceCollectionExtensions.cs
+++ b/src/RazorLight/Extensions/ServiceCollectionExtensions.cs
@@ -62,58 +62,6 @@ namespace RazorLight.Extensions
 			return builder;
 		}
 
-
-
-
-		///// <summary>
-		///// Adds required RazorLightProject
-		///// </summary>
-		///// <param name="services"></param>
-		///// <param name="root">Directory path to the root folder containing your Razor markup files.</param>
-		///// <param name="extension">If you wish, you can use a different extension than .cshtml.</param>
-		//public static void AddRazorLightFileSystemProject(this IServiceCollection services,string root, string extension = null)
-		//{
-		//	services.RemoveAll<RazorLightProject>();
-		//	RazorLightProject project;
-		//	if (String.IsNullOrEmpty(extension))
-		//	{
-		//		project = new FileSystemRazorProject(root);
-		//	}
-		//	else
-		//	{
-		//		project = new FileSystemRazorProject(root, extension);
-		//	}
-
-
-		//	services.AddSingleton<RazorLightProject>(project);
-		//}
-
-		///// <summary>
-		///// Adds required RazorLightProject
-		///// </summary>
-		///// <param name="services"></param>		
-		//public static void AddRazorLightEmbeddedResourcesProject(this IServiceCollection services, Type rootType)
-		//{
-		//	services.RemoveAll<RazorLightProject>();
-		//	RazorLightProject project = null;
-		//	project = new EmbeddedRazorProject(rootType);
-		//	services.AddSingleton<RazorLightProject>(project);
-		//}
-
-		///// <summary>
-		///// Adds required RazorLightProject
-		///// </summary>
-		///// <param name="services"></param>		
-		//public static void AddRazorLightEmbeddedResourcesProject(this IServiceCollection services, Assembly assembly, string rootNamespace = null)
-		//{
-		//	services.RemoveAll<RazorLightProject>();
-		//	RazorLightProject project = null;
-		//	project = new EmbeddedRazorProject(assembly, rootNamespace);
-		//	services.AddSingleton<RazorLightProject>(project);
-		//}
-
-
-
 		private static void AddEngineRenderCallbacks(IRazorLightEngine engine, IServiceProvider services)
 		{
 			var injector = services.GetRequiredService<PropertyInjector>();

--- a/src/RazorLight/Extensions/ServiceCollectionExtensions.cs
+++ b/src/RazorLight/Extensions/ServiceCollectionExtensions.cs
@@ -1,7 +1,13 @@
 ﻿using System;
+using System.Reflection;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using RazorLight.Caching;
+using RazorLight.Compilation;
 using RazorLight.DependencyInjection;
+using RazorLight.Generation;
+using RazorLight.Razor;
 
 namespace RazorLight.Extensions
 {
@@ -29,6 +35,79 @@ namespace RazorLight.Extensions
 				return engine;
 			});
 		}
+
+		public static RazorLightDependencyBuilder AddRazorLight(this IServiceCollection services)
+		{
+			services = services ?? throw new ArgumentNullException(nameof(services));
+
+			services.TryAddSingleton<PropertyInjector>();
+			services.TryAddSingleton<ICachingProvider, MemoryCachingProvider>();
+			services.TryAddSingleton<RazorSourceGenerator>();
+			services.TryAddSingleton<IRazorTemplateCompiler, RazorTemplateCompiler>();
+			services.TryAddSingleton<ITemplateFactoryProvider, TemplateFactoryProvider>();			
+			services.TryAddSingleton<IMetadataReferenceManager, DefaultMetadataReferenceManager>();
+			services.TryAddSingleton<ICompilationService, RoslynCompilationService>();
+
+
+			services.TryAddSingleton<IEngineHandler, EngineHandler>();
+			services.TryAddSingleton<IRazorLightEngine, RazorLightEngine>();
+
+			RazorLightDependencyBuilder builder = new RazorLightDependencyBuilder(services);
+
+			return builder;
+		}
+
+
+
+
+		///// <summary>
+		///// Adds required RazorLightProject
+		///// </summary>
+		///// <param name="services"></param>
+		///// <param name="root">Directory path to the root folder containing your Razor markup files.</param>
+		///// <param name="extension">If you wish, you can use a different extension than .cshtml.</param>
+		//public static void AddRazorLightFileSystemProject(this IServiceCollection services,string root, string extension = null)
+		//{
+		//	services.RemoveAll<RazorLightProject>();
+		//	RazorLightProject project;
+		//	if (String.IsNullOrEmpty(extension))
+		//	{
+		//		project = new FileSystemRazorProject(root);
+		//	}
+		//	else
+		//	{
+		//		project = new FileSystemRazorProject(root, extension);
+		//	}
+
+
+		//	services.AddSingleton<RazorLightProject>(project);
+		//}
+
+		///// <summary>
+		///// Adds required RazorLightProject
+		///// </summary>
+		///// <param name="services"></param>		
+		//public static void AddRazorLightEmbeddedResourcesProject(this IServiceCollection services, Type rootType)
+		//{
+		//	services.RemoveAll<RazorLightProject>();
+		//	RazorLightProject project = null;
+		//	project = new EmbeddedRazorProject(rootType);
+		//	services.AddSingleton<RazorLightProject>(project);
+		//}
+
+		///// <summary>
+		///// Adds required RazorLightProject
+		///// </summary>
+		///// <param name="services"></param>		
+		//public static void AddRazorLightEmbeddedResourcesProject(this IServiceCollection services, Assembly assembly, string rootNamespace = null)
+		//{
+		//	services.RemoveAll<RazorLightProject>();
+		//	RazorLightProject project = null;
+		//	project = new EmbeddedRazorProject(assembly, rootNamespace);
+		//	services.AddSingleton<RazorLightProject>(project);
+		//}
+
+
 
 		private static void AddEngineRenderCallbacks(IRazorLightEngine engine, IServiceProvider services)
 		{

--- a/src/RazorLight/RazorLightDependencyBuilder.cs
+++ b/src/RazorLight/RazorLightDependencyBuilder.cs
@@ -1,0 +1,54 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using RazorLight.Caching;
+using RazorLight.Razor;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace RazorLight
+{
+	public class RazorLightDependencyBuilder
+	{
+		IServiceCollection _services;
+		public RazorLightDependencyBuilder(IServiceCollection services)
+		{
+			_services = services;
+		}
+
+		public RazorLightDependencyBuilder UseFileSystemProject(string root, string extension = null)
+		{
+			_services.RemoveAll<RazorLightProject>();
+
+			RazorLightProject project;
+			if (String.IsNullOrEmpty(extension))
+			{
+				project = new FileSystemRazorProject(root);
+			}
+			else
+			{
+				project = new FileSystemRazorProject(root, extension);
+			}
+
+			_services.AddSingleton<RazorLightProject>(project);
+			return this;
+		}
+
+		public RazorLightDependencyBuilder UseMemoryCachingProvider()
+		{
+			_services.RemoveAll<ICachingProvider>();
+			_services.AddSingleton<ICachingProvider, MemoryCachingProvider>();
+			return this;
+		}
+
+		public RazorLightDependencyBuilder UseEmbeddedResourcesProject(Type rootType)
+		{
+			_services.RemoveAll<RazorLightProject>();
+			RazorLightProject project = new EmbeddedRazorProject(rootType);
+			_services.AddSingleton<RazorLightProject>(project);
+			return this;
+		}
+
+
+	}
+}

--- a/src/RazorLight/RazorLightDependencyBuilder.cs
+++ b/src/RazorLight/RazorLightDependencyBuilder.cs
@@ -1,9 +1,13 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Razor;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using RazorLight.Caching;
+using RazorLight.Compilation;
 using RazorLight.Razor;
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 using System.Text;
 
 namespace RazorLight
@@ -49,6 +53,43 @@ namespace RazorLight
 			return this;
 		}
 
+		public RazorLightDependencyBuilder UseNetFrameworkLegacyFix()
+		{
+			_services.RemoveAll<IAssemblyDirectoryFormatter>();
+			IAssemblyDirectoryFormatter formatter = new LegacyFixAssemblyDirectoryFormatter();
+			_services.AddSingleton<IAssemblyDirectoryFormatter>(formatter);
+			return this;
+		}
 
+		public RazorLightDependencyBuilder SetOperatingAssembly(Assembly assembly)
+		{
+			_services.Configure<RazorLightOptions>(x => x.OperatingAssembly = assembly);
+			return this;
+		}
+
+		public RazorLightDependencyBuilder ExcludeAssemblies(params string[] assemblyNames)
+		{
+			var excludedAssemblies = new HashSet<string>();
+
+			foreach (var assemblyName in assemblyNames)
+			{
+				excludedAssemblies.Add(assemblyName);
+			}
+
+			_services.Configure<RazorLightOptions>(x => x.ExcludedAssemblies = excludedAssemblies);
+			return this;
+		}
+
+		public RazorLightDependencyBuilder AddMetadataReferences(params MetadataReference[] metadata)
+		{
+			var metadataReferences = new HashSet<MetadataReference>();
+
+			foreach (var reference in metadata)
+			{
+				metadataReferences.Add(reference);
+			}
+			_services.Configure<RazorLightOptions>(x => x.AdditionalMetadataReferences = metadataReferences);
+			return this;
+		}
 	}
 }

--- a/src/RazorLight/RazorLightOptions.cs
+++ b/src/RazorLight/RazorLightOptions.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System;
 using RazorLight.Caching;
+using System.Reflection;
 
 namespace RazorLight
 {
@@ -29,6 +30,8 @@ namespace RazorLight
 		public virtual IList<Action<ITemplatePage>> PreRenderCallbacks { get; set; }
 
 		public ICachingProvider CachingProvider { get; set; }
+
+		public Assembly OperatingAssemlby { get; set; }
 
 		/// <summary>
 		/// Settings this to <c>true</c> will disable HTML encoding in all templates.

--- a/src/RazorLight/RazorLightOptions.cs
+++ b/src/RazorLight/RazorLightOptions.cs
@@ -31,7 +31,7 @@ namespace RazorLight
 
 		public ICachingProvider CachingProvider { get; set; }
 
-		public Assembly OperatingAssemlby { get; set; }
+		public Assembly OperatingAssembly { get; set; }
 
 		/// <summary>
 		/// Settings this to <c>true</c> will disable HTML encoding in all templates.

--- a/tests/RazorLight.Tests/Compilation/DefaultMetadataReferenceManagerTest.cs
+++ b/tests/RazorLight.Tests/Compilation/DefaultMetadataReferenceManagerTest.cs
@@ -13,14 +13,13 @@ namespace RazorLight.Tests.Compilation
 		[Fact]
 		public void Throws_OnEmptyManager_InConstructor()
 		{
-			Assert.Throws<ArgumentNullException>(() => { new DefaultMetadataReferenceManager(null, null); });
+			Assert.Throws<ArgumentNullException>(() => { new DefaultMetadataReferenceManager(null as HashSet<MetadataReference>, null); });
 		}
 
 		[Fact]
 		public void Ensure_AdditionalMetadata_IsApplied()
 		{
 			var metadata = new HashSet<MetadataReference>();
-
 			var manager = new DefaultMetadataReferenceManager(metadata);
 
 			Assert.NotNull(manager.AdditionalMetadataReferences);

--- a/tests/RazorLight.Tests/Compilation/RazorTemplateCompilerTest.cs
+++ b/tests/RazorLight.Tests/Compilation/RazorTemplateCompilerTest.cs
@@ -24,7 +24,8 @@ namespace RazorLight.Tests.Compilation
 			Action p1 = new Action(() => { new RazorTemplateCompiler(null, compilerService, project, options); });
 			Action p2 = new Action(() => { new RazorTemplateCompiler(generator, null, project, options); });
 			Action p3 = new Action(() => { new RazorTemplateCompiler(generator, compilerService, null, options); });
-			Action p4 = new Action(() => { new RazorTemplateCompiler(generator, compilerService, project, null); });
+			
+			Action p4 = new Action(() => { new RazorTemplateCompiler(generator, compilerService, project, null as RazorLightOptions); });
 
 			Assert.Throws<ArgumentNullException>(p1);
 			Assert.Throws<ArgumentNullException>(p2);

--- a/tests/RazorLight.Tests/Extensions/ServiceCollectionExtensionsTest.cs
+++ b/tests/RazorLight.Tests/Extensions/ServiceCollectionExtensionsTest.cs
@@ -120,7 +120,7 @@ namespace RazorLight.Tests.Extensions
 		}
 
 		[Fact]
-		public void Ensure_AddRazorLight_DI_Extension_works()
+		public void Ensure_DI_Extension_Can_Inject()
 		{
 			var services = GetServices();			
 			bool newRazorLightEngineCalled = false;
@@ -235,6 +235,25 @@ namespace RazorLight.Tests.Extensions
 			{
 				throw new NotImplementedException();
 			}
+		}
+
+		[Fact]
+		public void Try_Render_With_DI_Extension()
+		{
+			var path = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);		
+
+			var services = GetServices();
+			services.AddRazorLight()
+				.UseMemoryCachingProvider()
+				.UseFileSystemProject(Path.Combine(path, "Assets", "Files"));
+
+			var provider = services.BuildServiceProvider();
+			var engine = provider.GetService<IRazorLightEngine>();
+			var result = engine.CompileRenderAsync<object>("template1.cshtml", null).GetAwaiter().GetResult();
+
+
+
+
 		}
 	}
 }


### PR DESCRIPTION
**Creating Extension that allows inject all RazorLightEngine dependecies**
Found bug when using .Net Framework project  (#355)  wich can be easily solved when dependency injection is used to create RazorLightEngine 
so ... i did it?
**Usage**

			services.AddRazorLight()
				.UseMemoryCachingProvider()
				.UseFileSystemProject(root)
				.UseNetFrameworkLegacyFix();
				