### PR TITLE
Fix: respect DisableEncoding for cached templates (with test)

### DIFF
--- a/src/RazorLight/EngineHandler.cs
+++ b/src/RazorLight/EngineHandler.cs
@@ -50,27 +50,31 @@ namespace RazorLight
 		/// <returns>An instance of a template</returns>
 		public async Task<ITemplatePage> CompileTemplateAsync(string key)
 		{
+			ITemplatePage templatePage = null;
 			if (IsCachingEnabled)
 			{
 				var cacheLookupResult = Cache.RetrieveTemplate(key);
 				if (cacheLookupResult.Success)
 				{
-					return cacheLookupResult.Template.TemplatePageFactory();
+					templatePage = cacheLookupResult.Template.TemplatePageFactory();
 				}
 			}
 
-			CompiledTemplateDescriptor templateDescriptor = await Compiler.CompileAsync(key);
-			Func<ITemplatePage> templateFactory = FactoryProvider.CreateFactory(templateDescriptor);
-
-			if (IsCachingEnabled)
+			if(templatePage == null)
 			{
-				Cache.CacheTemplate(
-				key,
-				templateFactory,
-				templateDescriptor.ExpirationToken);
+				CompiledTemplateDescriptor templateDescriptor = await Compiler.CompileAsync(key);
+				Func<ITemplatePage> templateFactory = FactoryProvider.CreateFactory(templateDescriptor);
+
+				if(IsCachingEnabled) {
+					Cache.CacheTemplate(
+					key,
+					templateFactory,
+					templateDescriptor.ExpirationToken);
+				}
+
+				templatePage = templateFactory();
 			}
 
-			ITemplatePage templatePage = templateFactory();
 			templatePage.DisableEncoding = Options.DisableEncoding;
 			return templatePage;
 		}

--- a/src/RazorLight/EngineHandler.cs
+++ b/src/RazorLight/EngineHandler.cs
@@ -75,7 +75,7 @@ namespace RazorLight
 				templatePage = templateFactory();
 			}
 
-			templatePage.DisableEncoding = Options.DisableEncoding;
+			templatePage.DisableEncoding = Options.DisableEncoding ?? false;
 			return templatePage;
 		}
 

--- a/src/RazorLight/RazorLightOptions.cs
+++ b/src/RazorLight/RazorLightOptions.cs
@@ -16,7 +16,6 @@ namespace RazorLight
 			AdditionalMetadataReferences = new HashSet<MetadataReference>();
 			ExcludedAssemblies = new HashSet<string>();
 			PreRenderCallbacks = new List<Action<ITemplatePage>>();
-			DisableEncoding = false;
 		}
 
 		public ISet<string> Namespaces { get; set; }
@@ -38,6 +37,6 @@ namespace RazorLight
 		/// It can be re-enabled by setting <c>DisableEncoding = false</c> in the
 		/// template.
 		/// </summary>
-		public bool DisableEncoding { get; set; }
+		public bool? DisableEncoding { get; set; }
 	}
 }

--- a/tests/RazorLight.Tests/Caching/DefaultCachingProviderTest.cs
+++ b/tests/RazorLight.Tests/Caching/DefaultCachingProviderTest.cs
@@ -1,6 +1,7 @@
 ﻿using Moq;
 using RazorLight.Caching;
 using System;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace RazorLight.Tests.Caching
@@ -67,6 +68,27 @@ namespace RazorLight.Tests.Caching
 			Assert.NotNull(templateResult);
 			Assert.Null(templateResult.Template.TemplatePageFactory);
 			Assert.False(templateResult.Success);
+		}
+
+		[Fact]
+		public void Respects_DisabledEncoding_On_CachedTemplates()
+		{
+			string templateKey = "Assets.Embedded.Empty.cshtml";
+		
+			var engine = new RazorLightEngineBuilder()
+				.DisableEncoding()
+				.UseMemoryCachingProvider()
+				.UseEmbeddedResourcesProject(typeof(Root))
+				
+				.Build();
+			var testCompileToCache = engine.CompileTemplateAsync(templateKey).Result;
+		
+			Assert.True(testCompileToCache.DisableEncoding);
+		
+			var cachedCompile = engine.CompileTemplateAsync(templateKey).Result;
+		
+			Assert.True(cachedCompile.DisableEncoding);
+		
 		}
 
 		private Func<ITemplatePage> GetTestFactory(string key = "key")


### PR DESCRIPTION
Added a test to confirm the changes work as expected 
Changed RazorLightEngineBuilder to use the options object passed in by `UseOptions()`. I also found there could be options being overwritten between an options object passed in and fluent configuration, so some checks were added which will throw an exception if a conflict is found. 
Added several more tests to confirm that the above changes work, test suite passed