### PR TITLE
Change exception type/message when project item does not exist

### DIFF
--- a/src/RazorLight/Generation/RazorSourceGenerator.cs
+++ b/src/RazorLight/Generation/RazorSourceGenerator.cs
@@ -71,7 +71,7 @@ namespace RazorLight.Generation
 
 			if (!projectItem.Exists)
 			{
-				throw new TemplateNotFoundException($"Project can not find template with key {projectItem.Key}");
+				throw new InvalidOperationException($"RazorLightProjectItem with key {projectItem.Key} must exist");
 			}
 
 			RazorCodeDocument codeDocument = await CreateCodeDocumentAsync(projectItem);
@@ -108,7 +108,7 @@ namespace RazorLight.Generation
 
 			if (!projectItem.Exists)
 			{
-				throw new InvalidOperationException($"Project can not find template with key {projectItem.Key}");
+				throw new InvalidOperationException($"RazorLightProjectItem with key {projectItem.Key} must exist");
 			}
 
 			using (var stream = projectItem.Read())

--- a/src/RazorLight/Generation/RazorSourceGenerator.cs
+++ b/src/RazorLight/Generation/RazorSourceGenerator.cs
@@ -71,7 +71,8 @@ namespace RazorLight.Generation
 
 			if (!projectItem.Exists)
 			{
-				throw new InvalidOperationException($"RazorLightProjectItem with key {projectItem.Key} must exist");
+				throw new InvalidOperationException($"{nameof(RazorLightProjectItem)} of type " +
+					$"{projectItem.GetType().FullName} with key {projectItem.Key} does not exist.");
 			}
 
 			RazorCodeDocument codeDocument = await CreateCodeDocumentAsync(projectItem);
@@ -108,7 +109,8 @@ namespace RazorLight.Generation
 
 			if (!projectItem.Exists)
 			{
-				throw new InvalidOperationException($"RazorLightProjectItem with key {projectItem.Key} must exist");
+				throw new InvalidOperationException($"{nameof(RazorLightProjectItem)} of type " +
+					$"{projectItem.GetType().FullName} with key {projectItem.Key} does not exist.");
 			}
 
 			using (var stream = projectItem.Read())

--- a/tests/RazorLight.Tests/Generation/RazorSourceGeneratorTest.cs
+++ b/tests/RazorLight.Tests/Generation/RazorSourceGeneratorTest.cs
@@ -130,6 +130,17 @@ namespace RazorLight.Tests
 		}
 
 		[Fact]
+		public async Task GenerateCode_ByProjectItem_Throws_On_Null_ProjectItem()
+		{
+			var generator = new RazorSourceGenerator(DefaultRazorEngine.Instance, project: null);
+
+			Func<Task> action = () => generator.GenerateCodeAsync((RazorLightProjectItem)null);
+
+			var exception = await Assert.ThrowsAsync<ArgumentNullException>(action);
+			Assert.Equal("projectItem", exception.ParamName);
+		}
+
+		[Fact]
 		public async Task GenerateCode_ByProjectItem_Throws_On_ProjectItem_Not_Exists()
 		{
 			var generator = new RazorSourceGenerator(DefaultRazorEngine.Instance, project: null);
@@ -143,7 +154,18 @@ namespace RazorLight.Tests
 			Func<Task> action = () => generator.GenerateCodeAsync(projectItem);
 
 			var exception = await Assert.ThrowsAsync<InvalidOperationException>(action);
-			Assert.Equal($"RazorLightProjectItem with key {projectItem.Key} must exist", exception.Message);
+			Assert.Equal($"{ nameof(RazorLightProjectItem)} of type {projectItem.GetType().FullName} with key {projectItem.Key} does not exist.", exception.Message);
+		}
+
+		[Fact]
+		public async Task CreateCodeDocumentAsync_Throws_On_Null_ProjectItem()
+		{
+			var generator = new RazorSourceGenerator(DefaultRazorEngine.Instance, project: null);
+
+			Func<Task> action = () => generator.CreateCodeDocumentAsync(null);
+
+			var exception = await Assert.ThrowsAsync<ArgumentNullException>(action);
+			Assert.Equal("projectItem", exception.ParamName);
 		}
 
 		[Fact]
@@ -160,7 +182,7 @@ namespace RazorLight.Tests
 			Func<Task> action = () => generator.CreateCodeDocumentAsync(projectItem);
 
 			var exception = await Assert.ThrowsAsync<InvalidOperationException>(action);
-			Assert.Equal($"RazorLightProjectItem with key {projectItem.Key} must exist", exception.Message);
+			Assert.Equal($"{ nameof(RazorLightProjectItem)} of type {projectItem.GetType().FullName} with key {projectItem.Key} does not exist.", exception.Message);
 		}
 	}
 }

--- a/tests/RazorLight.Tests/Generation/RazorSourceGeneratorTest.cs
+++ b/tests/RazorLight.Tests/Generation/RazorSourceGeneratorTest.cs
@@ -118,7 +118,6 @@ namespace RazorLight.Tests
 			Assert.Empty(result);
 		}
 
-
 		[Fact]
 		public async Task GenerateCode_ByKey_Throws_OnEmpty_Project()
 		{
@@ -128,6 +127,40 @@ namespace RazorLight.Tests
 
 			var exception = await Assert.ThrowsAsync<InvalidOperationException>(action);
 			Assert.Equal("Can not resolve a content for the template \"key\" as there is no project set. You can only render a template by passing it's content directly via string using corresponding function overload", exception.Message);
+		}
+
+		[Fact]
+		public async Task GenerateCode_ByProjectItem_Throws_On_ProjectItem_Not_Exists()
+		{
+			var generator = new RazorSourceGenerator(DefaultRazorEngine.Instance, project: null);
+
+			string templateKey = "Assets.Embedded.IDoNotExist.cshtml";
+
+			var projectItem = new EmbeddedRazorProjectItem(typeof(Root), templateKey);
+
+			Assert.False(projectItem.Exists);
+
+			Func<Task> action = () => generator.GenerateCodeAsync(projectItem);
+
+			var exception = await Assert.ThrowsAsync<InvalidOperationException>(action);
+			Assert.Equal($"RazorLightProjectItem with key {projectItem.Key} must exist", exception.Message);
+		}
+
+		[Fact]
+		public async Task CreateCodeDocumentAsync_Throws_On_ProjectItem_Not_Exists()
+		{
+			var generator = new RazorSourceGenerator(DefaultRazorEngine.Instance, project: null);
+
+			string templateKey = "Assets.Embedded.IDoNotExist.cshtml";
+
+			var projectItem = new EmbeddedRazorProjectItem(typeof(Root), templateKey);
+
+			Assert.False(projectItem.Exists);
+
+			Func<Task> action = () => generator.CreateCodeDocumentAsync(projectItem);
+
+			var exception = await Assert.ThrowsAsync<InvalidOperationException>(action);
+			Assert.Equal($"RazorLightProjectItem with key {projectItem.Key} must exist", exception.Message);
 		}
 	}
 }


### PR DESCRIPTION
This is related to the discussion in #378  
`RazorSourceGenerator.GenerateCodeAsync(RazorLightProjectItem projectItem)` and `RazorSourceGenerator.CreateCodeDocumentAsync(RazorLightProjectItem projectItem)` both accept a `RazorLightProjectItem` with the precondition that the `.Exists` property is true. Previously, when this precondition was not met, `GenerateCodeAsync` threw a `TemplateNotFoundException` while `CreateCodeDoucmentAsync` threw a `InvalidOperationException`.  The exception language and type (in `GenerateCodeAsync `) made it sound like these methods are trying to "look up" a template, when in reality they are only checking the `Exists` property on the project item. These changes clarify the behavior of these methods and make the exception type consistent.