### PR TITLE
Change targeting for .Net standard 2.0

### DIFF
--- a/src/RazorLight/RazorLight.csproj
+++ b/src/RazorLight/RazorLight.csproj
@@ -19,15 +19,15 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.CodeAnalysis.Razor" Version="2.1.0)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Razor" Version="2.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Html.Abstractions" Version="2.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="2.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Language" Version="2.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Runtime" Version="2.1.0)" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="2.1.0)" />
+    <PackageReference Include="Microsoft.AspNetCore.Razor.Runtime" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.0)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.Primitives" Version="2.1.0" />

--- a/src/RazorLight/RazorLight.csproj
+++ b/src/RazorLight/RazorLight.csproj
@@ -19,18 +19,18 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.CodeAnalysis.Razor" Version="[2.1.0,3)" />
-    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="[2.1.0,3)" />
-    <PackageReference Include="Microsoft.AspNetCore.Html.Abstractions" Version="[2.1.0,3)" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="[2.1.0,3)" />
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Language" Version="[2.1.0,3)" />
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Runtime" Version="[2.1.0,3)" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="[2.1.0,3)" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="[2.1.0,3)" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[2.1.0,3)" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="[2.1.0,3)" />
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="[2.1.0,3)" />
-    <PackageReference Include="Microsoft.Extensions.Primitives" Version="[2.1.0,3)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Razor" Version="2.1.0)" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Html.Abstractions" Version="2.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="2.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Razor.Language" Version="2.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Razor.Runtime" Version="2.1.0)" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="2.1.0)" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.0)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Primitives" Version="2.1.0" />
     <PackageReference Include="System.Buffers" Version="4.5.0" />
   </ItemGroup>
         


### PR DESCRIPTION
As in this discussion: https://github.com/toddams/RazorLight/issues/390
Change the targeting for .net standard to be more flexible.
