### PR TITLE
Change service extension return type

### DIFF
--- a/src/RazorLight/Extensions/ServiceCollectionExtensions.cs
+++ b/src/RazorLight/Extensions/ServiceCollectionExtensions.cs
@@ -14,7 +14,7 @@ namespace RazorLight.Extensions
 {
 	public static class ServiceCollectionExtensions
 	{
-		public static void AddRazorLight(this IServiceCollection services, Func<IRazorLightEngine> engineFactoryProvider)
+		public static IServiceCollection AddRazorLight(this IServiceCollection services, Func<IRazorLightEngine> engineFactoryProvider)
 		{
 			if (services == null)
 			{
@@ -36,6 +36,8 @@ namespace RazorLight.Extensions
 
 				return engine;
 			});
+
+			return services;
 			
 		}
 


### PR DESCRIPTION
Most `IServiceCollection` extension methods return the `IServiceCollection` instance passed in. This change updates the `AddRazorLight` method to be consistent, so that something like this is possible:

```
var serviceProvider = new ServiceCollection()
	.AddRazorLight(() =>
		new RazorLightEngineBuilder()
		.UseEmbeddedResourcesProject(typeof(Program))
		.UseMemoryCachingProvider()
		.Build())
	.AddSingleton(new MyService())
	.BuildServiceProvider();
```