### PR TITLE
Added diagnostics to TemplateCompilationException

### DIFF
--- a/src/RazorLight/Compilation/RoslynCompilationService.cs
+++ b/src/RazorLight/Compilation/RoslynCompilationService.cs
@@ -116,20 +116,23 @@ namespace RazorLight.Compilation
 					StringBuilder builder = new StringBuilder();
 					builder.AppendLine("Failed to compile generated Razor template:");
 
-					var errorMessages = new List<string>();
+					var compilationDiagnostics = new List<TemplateCompilationDiagnostic>();
+					
 					foreach (Diagnostic diagnostic in errorsDiagnostics)
 					{
 						FileLinePositionSpan lineSpan = diagnostic.Location.SourceTree.GetMappedLineSpan(diagnostic.Location.SourceSpan);
 						string errorMessage = diagnostic.GetMessage();
 						string formattedMessage = $"- ({lineSpan.StartLinePosition.Line}:{lineSpan.StartLinePosition.Character}) {errorMessage}";
 
-						errorMessages.Add(formattedMessage);
+						var compilationDiagnostic = new TemplateCompilationDiagnostic(errorMessage, formattedMessage, lineSpan);
+						compilationDiagnostics.Add(compilationDiagnostic);
+
 						builder.AppendLine(formattedMessage);
 					}
 
 					builder.AppendLine("\nSee CompilationErrors for detailed information");
 
-					throw new TemplateCompilationException(builder.ToString(), errorMessages);
+					throw new TemplateCompilationException(builder.ToString(),compilationDiagnostics);
 				}
 
 				assemblyStream.Seek(0, SeekOrigin.Begin);

--- a/src/RazorLight/Compilation/TemplateCompilationDiagnostic.cs
+++ b/src/RazorLight/Compilation/TemplateCompilationDiagnostic.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.CodeAnalysis;
+
+namespace RazorLight.Compilation
+{
+	public class TemplateCompilationDiagnostic
+	{
+		public string ErrorMessage { get; }
+		public string FormattedMessage { get; }
+		public FileLinePositionSpan? LineSpan { get; }
+
+		public TemplateCompilationDiagnostic(string errorMessage, string formattedMessage, FileLinePositionSpan? lineSpan)
+		{
+			ErrorMessage = errorMessage;
+			FormattedMessage = formattedMessage;
+			LineSpan = lineSpan;
+		}
+	}
+}

--- a/src/RazorLight/Compilation/TemplateCompilationException.cs
+++ b/src/RazorLight/Compilation/TemplateCompilationException.cs
@@ -1,18 +1,33 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
 
 namespace RazorLight.Compilation
 {
 	public class TemplateCompilationException : RazorLightException
 	{
-		private readonly List<string> compilationErrors;
+		private readonly List<TemplateCompilationDiagnostic> compilationDiagnostics = new List<TemplateCompilationDiagnostic>();
 
-		public IReadOnlyList<string> CompilationErrors => compilationErrors;
+		public IReadOnlyList<string> CompilationErrors => compilationDiagnostics?.Select(x => x.FormattedMessage).ToList() ?? new List<string>();
 
+		public IReadOnlyList<TemplateCompilationDiagnostic> CompilationDiagnostics => compilationDiagnostics;
+
+		[Obsolete("Use constructor that takes enumerable of TemplateCompilationDiagnostic as input parameters")]
 		public TemplateCompilationException(string message, IEnumerable<string> errors) : base(message)
 		{
-			this.compilationErrors = new List<string>();
 			if (errors != null)
-				compilationErrors.AddRange(errors);
+			{
+				compilationDiagnostics.AddRange(errors.Select(x => new TemplateCompilationDiagnostic(x, x, null)));	
+			}
+		}
+		
+		public TemplateCompilationException(string message, IEnumerable<TemplateCompilationDiagnostic> diagnostics) : base(message)
+		{
+			if (diagnostics != null)
+			{
+				compilationDiagnostics.AddRange(diagnostics);
+			}
 		}
 	}
 }

--- a/tests/RazorLight.Tests/Compilation/RoslynCompilerServiceTest.cs
+++ b/tests/RazorLight.Tests/Compilation/RoslynCompilerServiceTest.cs
@@ -275,6 +275,8 @@ namespace RazorLight.Tests.Compilation
 
 			var ex = Assert.Throws<TemplateCompilationException>(() => compiler.CompileAndEmit(template));
 			Assert.NotEmpty(ex.CompilationErrors);
+			Assert.NotEmpty(ex.CompilationDiagnostics);
+			Assert.Equal(1, ex.CompilationDiagnostics.Count);
 			Assert.Equal(1, ex.CompilationErrors.Count);
 		}
 

--- a/tests/RazorLight.Tests/Compilation/TemplateCompilationExceptionTests.cs
+++ b/tests/RazorLight.Tests/Compilation/TemplateCompilationExceptionTests.cs
@@ -1,0 +1,59 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+using RazorLight.Compilation;
+using Xunit;
+
+namespace RazorLight.Tests.Compilation
+{
+	public class TemplateCompilationExceptionTests
+	{
+		[Fact]
+		public void Ensure_CompilationDiagnostics_FormattedMessage_Matches_CompilationErrors()
+		{
+			var exception = new TemplateCompilationException("Error message", new TemplateCompilationDiagnostic[]
+			{
+				new TemplateCompilationDiagnostic("diagnosticMessage", "diagnosticFormattedMessage",
+					new FileLinePositionSpan("path", new LinePosition(3, 1), new LinePosition(4, 2)))
+			});
+			
+			Assert.NotEmpty(exception.CompilationDiagnostics);
+			Assert.NotEmpty(exception.CompilationErrors);
+			
+			Assert.Equal(1, exception.CompilationDiagnostics.Count);
+			Assert.Equal(1, exception.CompilationErrors.Count);
+
+			var firstDiagnostic = exception.CompilationDiagnostics[0];
+			Assert.Equal("diagnosticMessage",firstDiagnostic.ErrorMessage);
+			Assert.Equal("diagnosticFormattedMessage",firstDiagnostic.FormattedMessage);
+			Assert.Equal("path",firstDiagnostic.LineSpan?.Path);
+			Assert.Equal(3,firstDiagnostic.LineSpan?.StartLinePosition.Line);
+			Assert.Equal(1,firstDiagnostic.LineSpan?.StartLinePosition.Character);
+			Assert.Equal(4,firstDiagnostic.LineSpan?.EndLinePosition.Line);
+			Assert.Equal(2,firstDiagnostic.LineSpan?.EndLinePosition.Character);
+			
+			Assert.Equal(firstDiagnostic.FormattedMessage, exception.CompilationErrors[0]);
+		}
+		
+		[Fact]
+		public void Ensure_InitalizedWtihErrors_FormattedMessage_Matches_CompilationErrors()
+		{
+			var exception = new TemplateCompilationException("Error message", new string[]
+			{
+				"formattedMessage"
+			});
+			
+			Assert.NotEmpty(exception.CompilationDiagnostics);
+			Assert.NotEmpty(exception.CompilationErrors);
+			
+			Assert.Equal(1, exception.CompilationDiagnostics.Count);
+			Assert.Equal(1, exception.CompilationErrors.Count);
+
+			var firstDiagnostic = exception.CompilationDiagnostics[0];
+			Assert.Equal("formattedMessage",firstDiagnostic.ErrorMessage);
+			Assert.Equal("formattedMessage",firstDiagnostic.FormattedMessage);
+			Assert.Null(firstDiagnostic.LineSpan);
+
+			Assert.Equal(firstDiagnostic.FormattedMessage, exception.CompilationErrors[0]);
+		}
+	}
+}


### PR DESCRIPTION
I've made an update to the TemplateCompilationException to include a list of wrapped diagnostics. Primarily to include the FileLinePositionSpan