### PR TITLE
New method to render a template where its key is a type of the model

### DIFF
--- a/src/RazorLight/IRazorLightEngine.cs
+++ b/src/RazorLight/IRazorLightEngine.cs
@@ -27,6 +27,15 @@ namespace RazorLight
 		/// <returns>Rendered template as a string result</returns>
 		Task<string> CompileRenderAsync<T>(string key, T model, ExpandoObject viewBag = null);
 
+		/// <summary>
+		/// Compiles and renders a template by the model provided/>
+		/// </summary>
+		/// <typeparam name="T">Type of the model (will be used as key of the template)</typeparam>
+		/// <param name="model">Template model</param>
+		/// <param name="viewBag">Dynamic viewBag of the template</param>
+		/// <returns>Rendered template as a string result</returns>
+		Task<string> CompileRenderModelAsync<T>(T model, ExpandoObject viewBag = null);
+		
 		[Obsolete("Please, use generic version of CompileRenderAsync", true)]
 		Task<string> CompileRenderAsync(string key, object model, Type modelType, ExpandoObject viewBag = null);
 

--- a/src/RazorLight/RazorLightEngine.cs
+++ b/src/RazorLight/RazorLightEngine.cs
@@ -53,6 +53,12 @@ namespace RazorLight
 			return _handler.CompileRenderAsync(key, model, viewBag);
 		}
 
+		public Task<string> CompileRenderModelAsync<T>(T model, ExpandoObject viewBag = null)
+		{
+			var key = _handler.Options.EnableModelFullTypeNameAsTemplateKey ?? false ? typeof(T).FullName : typeof(T).Name;
+			return CompileRenderAsync(key, model, viewBag);
+		}
+
 		/// <inheritdoc cref="IRazorLightEngine"/>
 		public Task<string> CompileRenderStringAsync<T>(
 			string key,

--- a/src/RazorLight/RazorLightOptions.cs
+++ b/src/RazorLight/RazorLightOptions.cs
@@ -43,5 +43,11 @@ namespace RazorLight
 		/// Setting this to <c>true</c> provides more information in exceptions.
 		/// </summary>
 		public bool? EnableDebugMode { get; set; }
+		
+		/// <summary>
+		/// Setting this to <c>true</c> will use fully qualified type's name of the model as template key
+		/// By default the short name of the type is used. 
+		/// </summary>
+		public bool? EnableModelFullTypeNameAsTemplateKey { get; set; }
 	}
 }

--- a/tests/RazorLight.Tests/Assets/Files/RazorLight.Tests.Integration.TestViewModel.cshtml
+++ b/tests/RazorLight.Tests/Assets/Files/RazorLight.Tests.Integration.TestViewModel.cshtml
@@ -1,0 +1,2 @@
+@model RazorLight.Tests.Integration.TestViewModel
+We are rendering this with @Model.Name by model type only!

--- a/tests/RazorLight.Tests/Assets/Files/TestViewModel.cshtml
+++ b/tests/RazorLight.Tests/Assets/Files/TestViewModel.cshtml
@@ -1,0 +1,2 @@
+@model RazorLight.Tests.Integration.TestViewModel
+We are rendering this with @Model.Name by model type only!

--- a/tests/RazorLight.Tests/Extensions/ServiceCollectionExtensionsTest.cs
+++ b/tests/RazorLight.Tests/Extensions/ServiceCollectionExtensionsTest.cs
@@ -334,6 +334,11 @@ namespace RazorLight.Tests.Extensions
 				throw new NotImplementedException();
 			}
 
+			public Task<string> CompileRenderModelAsync<T>(T model, ExpandoObject viewBag = null)
+			{
+				throw new NotImplementedException();
+			}
+
 			public Task<string> CompileRenderAsync(string key, object model, Type modelType, ExpandoObject viewBag = null)
 			{
 				throw new NotImplementedException();

--- a/tests/RazorLight.Tests/Integration/RendererCommonCasesTests.Should_Render_By_Model_FullTypeName_Async.verified.txt
+++ b/tests/RazorLight.Tests/Integration/RendererCommonCasesTests.Should_Render_By_Model_FullTypeName_Async.verified.txt
@@ -1,0 +1,1 @@
+We are rendering this with RazorLight by model type only!

--- a/tests/RazorLight.Tests/Integration/RendererCommonCasesTests.Should_Render_By_Model_ShortTypeName_Async.verified.txt
+++ b/tests/RazorLight.Tests/Integration/RendererCommonCasesTests.Should_Render_By_Model_ShortTypeName_Async.verified.txt
@@ -1,0 +1,1 @@
+We are rendering this with RazorLight by model type only!

--- a/tests/RazorLight.Tests/Integration/RendererCommonCasesTests.cs
+++ b/tests/RazorLight.Tests/Integration/RendererCommonCasesTests.cs
@@ -143,5 +143,51 @@ namespace RazorLight.Tests.Integration
 			var renderedResult = await engine.CompileRenderAsync("template8.cshtml", model);
 			await Verifier.Verify(renderedResult);
 		}
+		
+		[Fact]
+		public async Task Should_Render_By_Model_ShortTypeName_Async()
+		{
+			var path = DirectoryUtils.RootDirectory;
+
+			var engine = new RazorLightEngineBuilder()
+#if NETFRAMEWORK
+				.SetOperatingAssembly(typeof(Root).Assembly)
+#endif
+				.UseFileSystemProject(Path.Combine(path, "Assets", "Files"))
+				.Build();
+
+			var model = new TestViewModel
+			{
+				Name = "RazorLight",
+				NumberOfItems = 400
+			};
+			var renderedResult = await engine.CompileRenderModelAsync(model);
+			await Verifier.Verify(renderedResult);
+		}
+		
+		[Fact]
+		public async Task Should_Render_By_Model_FullTypeName_Async()
+		{
+			var path = DirectoryUtils.RootDirectory;
+
+			var engine = new RazorLightEngineBuilder()
+#if NETFRAMEWORK
+				.SetOperatingAssembly(typeof(Root).Assembly)
+#endif
+				.UseFileSystemProject(Path.Combine(path, "Assets", "Files"))
+				.UseOptions(new RazorLightOptions
+				{
+					EnableModelFullTypeNameAsTemplateKey = true
+				})
+				.Build();
+
+			var model = new TestViewModel
+			{
+				Name = "RazorLight",
+				NumberOfItems = 400
+			};
+			var renderedResult = await engine.CompileRenderModelAsync(model);
+			await Verifier.Verify(renderedResult);
+		}
 	}
 }


### PR DESCRIPTION
New method CompileRenderModelAsync has been added- an ability to compile and render a template based on model instance only. So, as the template key in this case will be full or short type name of the model. Default option - engine use short type name, but this behaviour can be overriden in options (EnableModelFullTypeNameAsTemplateKey)
