### PR TITLE
updating deprecated dependencies for .NET 6

### DIFF
--- a/src/RazorLight/RazorLight.csproj
+++ b/src/RazorLight/RazorLight.csproj
@@ -71,14 +71,14 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Razor" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Primitives" Version="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="6.0.3" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Razor" Version="6.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="6.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.3" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.3" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="6.0.3" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="6.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Primitives" Version="6.0.3" />
     <PackageReference Include="System.Buffers" Version="4.5.1" />
   </ItemGroup>
 

--- a/tests/RazorLight.Tests/RazorLight.Tests.csproj
+++ b/tests/RazorLight.Tests/RazorLight.Tests.csproj
@@ -69,8 +69,8 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="6.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR updates the deprecated vulnerable dependencies for .NET 6 mentioned in #547.

Please note that there are 9 failed tests in this build, but they were failing even before the package update.

If you want, I can try to update some other, non-critical packages, including those for other .NET versions, but I'll probably need some guidance on overall project strategy.